### PR TITLE
fix floating point errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,37 @@ Convert a `Date` into a string representing Julian Date.
 
 Convert a Julian Date to a javascript `Date`.
 
+### julian.toJulianDay(date)
+
+return a javascript `Date` or `timestamp` to the julian day.
+An integer day is returned.
+
+### julian.toMillisecondsInJulianDay (date)
+
+returns the number of milliseconds since the start of
+the julian day. Note, the julian day starts at noon,
+not at midnight. This seems strange, if you don't have
+an accurate clock, then finding noon accurately is easy
+(from the sun) but finding midnight is not easy. Julian
+days have been used by astronomers since before accurate clocks.
+
+### julian.fromJulianDayAndMilliseconds(day, ms)
+
+Converts a julian day and ms back to a javascript timestamp.
+Also, note that this is reversable with out floating point errors.
+
+``` js
+var date = Date.now()
+
+assert.equal(
+  julian.fromJulianDayAndMilliseconds(
+    julian.toJulianDay(date),
+    julian.toMillisecondsInJulianDay(date)
+  ),
+  date
+)
+```
+
 ## notice
 
 Date systems are a mess. Leap years, leap seconds, epochs, different calendars using the same nomenclature, different countries using different calendars at the same time, etc.
@@ -41,3 +72,5 @@ MIT
 ## author
 
 Stepan Stolyarov <stepan.stolyarov@gmail.com>
+
+

--- a/index.js
+++ b/index.js
@@ -1,10 +1,31 @@
 module.exports = convert;
 module.exports.toDate = convertToDate;
 
+module.exports.toJulianDay = toJulianDay;
+module.exports.toMillisecondsInJulianDay = toMillisecondsInJulianDay;
+module.exports.fromJulianDayAndMilliseconds = fromJulianDayAndMilliseconds;
+
+var DAY = 86400000;
+var HALF_DAY = DAY/2;
+var UNIX_EPOCH_JULIAN_DATE = 2440587.5;
+var UNIX_EPOCH_JULIAN_DAY = 2440587;
+
 function convert(date) {
-  return (((+date) / 86400000) + 2440587.5).toFixed(6);
+  return (toJulianDay(date) + (toMillisecondsInJulianDay(date)/DAY)).toFixed(6);
 };
 
 function convertToDate(julian) {
-  return new Date((Number(julian) - 2440587.5) * 86400000);
+  return new Date((Number(julian) - UNIX_EPOCH_JULIAN_DATE) * DAY);
+};
+
+function toJulianDay (date) {
+  return ~~((+date+HALF_DAY)/DAY) + UNIX_EPOCH_JULIAN_DAY;
+};
+
+function toMillisecondsInJulianDay (date) {
+  return (+date+HALF_DAY)%DAY;
+};
+
+function fromJulianDayAndMilliseconds(day, ms) {
+  return (day-UNIX_EPOCH_JULIAN_DATE)*DAY + ms;
 };

--- a/package.json
+++ b/package.json
@@ -25,6 +25,6 @@
     "url": "https://github.com/stevebest/julian-date/issues"
   },
   "devDependencies": {
-    "tap": "~0.4.6"
+    "tap": "^10.3.0"
   }
 }

--- a/test/test.js
+++ b/test/test.js
@@ -14,13 +14,79 @@ test('from Date to JD', function (t) {
 test('from JD to Date', function (t) {
   t.equal(+julian.toDate('2440587.500000'), +new Date(0), 'unix epoch');
   t.equal(+julian.toDate('2451545.000000'), +new Date('2000-01-01T12:00:00.000Z'), 'noon of Jan 1, 2000');
+
+
   t.end();
 });
 
-test('to JD and back', function (t) {
+test('convert back and forth without floating point errors', function (t) {
   var now = new Date();
-  t.equal(+julian.toDate(julian(now)), +now);
+
+  t.equal(+
+    julian.fromJulianDayAndMilliseconds(
+      julian.toJulianDay(now),
+      julian.toMillisecondsInJulianDay(now)
+    ),
+    +now,
+    'now is converted to julian and back safely'
+  );
+
+
+  t.equal(
+    julian.toMillisecondsInJulianDay(new Date('2000-01-01T12:00:00.000Z')),
+    0,
+    'the day starts at noon, so noon is zero milliseconds'
+  )
+
+  t.equal(
+    julian.toJulianDay(new Date('1970-01-01T00:00:00.000Z')),
+    2440587,
+    'unix epoch starts on julian day 2440587'
+  )
+
+  t.equal(
+    julian.toMillisecondsInJulianDay(new Date('1970-01-01T00:00:00.000Z')),
+    43200000,
+    'unix epoch starts with half a julian day'
+  )
+
+  t.equal(
+    julian.toJulianDay(new Date('1970-01-01T12:00:00.000Z')),
+    2440588,
+    'first noon in unix epoch starts julian day 2440588'
+  )
+
+  t.equal(
+    julian.toMillisecondsInJulianDay(new Date('1970-01-01T12:00:00.000Z')),
+    0,
+    'unix epoch starts with half a julian day'
+  )
+
+
+  //the instance in time known as j2000, aka terriestial time
+  t.equal(
+    julian.toJulianDay(new Date('2000-01-01T12:00:00.000Z')),
+    2451545,
+    'toJulianDay is give correct julian day for j2000 epoch'
+  )
+  // test data taken from https://en.wikipedia.org/wiki/Epoch_(astronomy)#Julian_years_and_J2000
+
+  console.log(
+    new Date(julian.fromJulianDayAndMilliseconds(0, 0))
+  )
+
   t.end();
-});
+
+})
+
+
+
+
+
+
+
+
+
+
 
 

--- a/test/test.js
+++ b/test/test.js
@@ -12,13 +12,15 @@ test('from Date to JD', function (t) {
 });
 
 test('from JD to Date', function (t) {
-  t.equal(julian.toDate('2440587.500000').value, new Date(0).value, 'unix epoch');
-  t.equal(julian.toDate('2451545.000000').value, new Date('2000-01-01T12:00:00.000Z').value, 'noon of Jan 1, 2000');
+  t.equal(+julian.toDate('2440587.500000'), +new Date(0), 'unix epoch');
+  t.equal(+julian.toDate('2451545.000000'), +new Date('2000-01-01T12:00:00.000Z'), 'noon of Jan 1, 2000');
   t.end();
 });
 
 test('to JD and back', function (t) {
   var now = new Date();
-  t.equal(julian.toDate(julian(now)).value, now.value);
+  t.equal(+julian.toDate(julian(now)), +now);
   t.end();
 });
+
+


### PR DESCRIPTION
was very happy to find this module, but later discovered that it had some floating point errors. (also, the test cases actually were a false positive)

I changed the conversion functions to avoid division, which avoids floating point errors,
this means that dates are reliably converted from js timestamps to julian day and back.

`julian` still returns a julian date as a string to 6 decimal places, so this is backwards compatible, but I've also exposed the other functions I added making this a semver minor change.